### PR TITLE
feat: migrate to reusable_build.yml workflow

### DIFF
--- a/.github/workflows/build_and_functional_tests.yml
+++ b/.github/workflows/build_and_functional_tests.yml
@@ -1,0 +1,26 @@
+name: Build and run functional tests using ragger through reusable workflow
+
+# This workflow will build the app and then run functional tests using the Ragger framework upon Speculos emulation.
+# It calls a reusable workflow developed by Ledger's internal developer team to build the application and upload the
+# resulting binaries.
+# It then calls another reusable workflow to run the Ragger tests on the compiled application binary.
+#
+# The build part of this workflow is mandatory, this ensures that the app will be deployable in the Ledger App Store.
+# While the test part of this workflow is optional, having functional testing on your application is mandatory and this workflow and
+# tooling environment is meant to be easy to use and adapt after forking your application
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+      - main
+      - develop
+  pull_request:
+
+jobs:
+  build_application:
+    name: Build application using the reusable workflow
+    uses: LedgerHQ/ledger-app-workflows/.github/workflows/reusable_build.yml@v1
+    with:
+      builder: ledger-app-builder


### PR DESCRIPTION
This PR migrates the build workflow to use the reusable `reusable_build.yml` workflow from `ledger-app-workflows`.

## Changes
- Adds `.github/workflows/build_and_functional_tests.yml` using the reusable workflow pattern

## Benefits
- Consistency across all Ledger apps
- Centralized maintenance of build logic
- Automatic updates when the reusable workflow is improved

## Notes
⚠️ The artifact name `upload_app_binaries_artifact` contains a placeholder and may need to be updated with the correct app name.